### PR TITLE
Add a preference for `ui` extension host

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     ],
     "activationEvents": [],
     "main": "./dist/extension.js",
+
+    "extensionKind": ["ui", "workspace"],
+
     "contributes": {
         "commands": [
             {


### PR DESCRIPTION
See details in [the docs](https://code.visualstudio.com/api/advanced-topics/extension-host#extension-host-configurations). With this preference the extension becomes available by default for VSCode Remote SSH and Dev Container users - they don't need to install the extension on the remote host and the extension can only be installed locally on the user's host.